### PR TITLE
update python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN apk update && apk upgrade && apk add \
     nodejs \
     npm \
     jq \
-    python \
-    py-pip \
-    py2-pip && \
+    python3 \
+    py3-pip && \
     pip install --upgrade pip awscli s3cmd && \
     mkdir /root/.aws


### PR DESCRIPTION
> There is no longer a python package providing python2.

note from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.12.0